### PR TITLE
docs: add AGENTS.md with Cursor Cloud setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`view_primitives` is a single Ruby **gem** (a ViewComponent-based UI component
+library for Rails). There are **no long-running services, servers, databases, or
+ports** — "running" the project means running its test suite, linter, and the
+gem build. See `README.md` for the gem's purpose and public API, and
+`Rakefile` / `.github/workflows/main.yml` for the canonical commands.
+
+### Ruby toolchain (non-obvious)
+- Ruby is managed by **mise** (pinned to the version in `mise.toml` / `.ruby-version`).
+  Ruby is **not** a system package; it lives under `~/.local/share/mise`.
+- A **global** mise Ruby is configured (`mise use -g`), so `ruby`/`bundle` resolve
+  in any directory. Inside this repo `mise.toml` also pins the same version.
+- In a non-interactive shell where mise isn't activated, call it explicitly, e.g.
+  `~/.local/bin/mise exec -- bundle exec rake`. Interactive shells get mise via
+  `~/.bashrc`.
+
+### Commands (run from repo root)
+- Tests: `bundle exec rake test`
+- Lint: `bundle exec rubocop`
+- Tests + lint (default task): `bundle exec rake`
+- Build gem: `bundle exec rake build`
+- REPL with the gem loaded: `bin/console`
+- Multi-Rails matrix (optional): `bundle exec appraisal rails-8.1 rake test`
+  (matrix names: `rails-7.1`, `rails-7.2`, `rails-8.0`, `rails-8.1`).
+
+### Verifying the gem end-to-end (host Rails app)
+The gem's real flow is: install it into a Rails app, run generators to copy
+components, then render them with the `ui` helper. To exercise this manually,
+create a throwaway Rails app, add `gem "view_primitives", path: "<repo>"` plus
+`view_component` and `tailwindcss-rails`, then run
+`rails g view_primitives:install` and `rails g view_primitives:add button card badge`,
+import `@import "../stylesheets/view_primitives";` in the Tailwind entry, and
+render the components in a view. This is only needed for manual UI verification;
+the bundled `bundle exec rake test` already covers component rendering in-memory.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `view_primitives` Ruby gem and documents it for future Cloud agents.

This is a single Ruby **gem** (a ViewComponent-based UI component library for Rails) — there are **no services, servers, databases, or ports**. "Running" the project means running its tests, linter, and gem build.

### Changes
- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the mise-managed Ruby toolchain, canonical commands, and how to verify the gem end-to-end inside a throwaway host Rails app.

### Environment setup (configured separately, not code)
- Installed **mise** and Ruby `4.0.5` (per `mise.toml` / `.ruby-version`); installed Ruby build deps (`libyaml-dev`, etc.).
- Update script (runs on VM startup): `~/.local/bin/mise install` then `~/.local/bin/mise exec -- bundle install`.

### Verification
- ✅ `bundle exec rake test` — 460 runs, 0 failures.
- ✅ `bundle exec rubocop` — 30 files, no offenses.
- ✅ `bundle exec rake build` — built `view_primitives-0.2.0.gem`.
- ✅ End-to-end: created a throwaway Rails 8.1 app, added the gem via `path:`, ran `view_primitives:install` + `add button card badge`, and rendered the components in the browser.

[ViewPrimitives components rendered in a Rails app](https://cursor.com/agents/bc-18e11659-b10b-498a-802b-6b2e76cbbeea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fview_primitives_demo.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18e11659-b10b-498a-802b-6b2e76cbbeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18e11659-b10b-498a-802b-6b2e76cbbeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

