### PR TITLE
Fix Chart canvas colors and Esc key filter on 6 overlay components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Chart** resolves `var(--chart-1)`-style CSS custom properties to their computed value before handing colors to Chart.js — Canvas 2D's `fillStyle` cannot resolve CSS variables on its own, so every segment rendered black
+- **Chart** uses one color per data point (not per dataset) for `pie`/`doughnut`/`polarArea`, matching Chart.js's expected `backgroundColor` shape for single-dataset charts
+- **Dialog**, **Sheet**, **Drawer**, **Command**, **Menubar**, **Gallery** close on <kbd>Esc</kbd> again — the Stimulus key filter was `keydown.escape`, but Stimulus only recognizes the `esc` alias, so the action silently failed to bind (and threw in the console) on every one of these components
+
 ## [0.2.2] - 2026-07-15
 
 ### Fixed

--- a/lib/generators/view_primitives/add/templates/chart/chart_controller.js
+++ b/lib/generators/view_primitives/add/templates/chart/chart_controller.js
@@ -23,8 +23,18 @@ export default class extends Controller {
 
   connect() {
     const { labels, datasets, options = {}, colors } = JSON.parse(this.configValue)
-    const palette = colors?.length ? colors : DEFAULT_COLORS
+    const palette = (colors?.length ? colors : DEFAULT_COLORS).map((c) => this.#resolveColor(c))
+    const perSegment = ["pie", "doughnut", "polarArea"].includes(this.typeValue) && datasets.length === 1
     const coloredDatasets = datasets.map((dataset, index) => {
+      if (perSegment) {
+        const segmentColors = (dataset.data ?? []).map((_, i) => palette[i % palette.length])
+        return {
+          ...dataset,
+          backgroundColor: dataset.backgroundColor ?? segmentColors,
+          borderColor: dataset.borderColor ?? segmentColors
+        }
+      }
+
       const color = palette[index % palette.length]
       return {
         ...dataset,
@@ -39,7 +49,7 @@ export default class extends Controller {
       options: {
         responsive: true,
         maintainAspectRatio: true,
-        color: "var(--muted-foreground)",
+        color: this.#resolveColor("var(--muted-foreground)"),
         ...options
       }
     })
@@ -48,5 +58,15 @@ export default class extends Controller {
   disconnect() {
     this.#chart?.destroy()
     this.#chart = null
+  }
+
+  // Canvas fillStyle can't resolve CSS custom properties on its own —
+  // read the computed value from the DOM before handing it to Chart.js.
+  #resolveColor(value) {
+    const match = /^var\((--[^),]+)\)$/.exec(value?.trim() ?? "")
+    if (!match) return value
+
+    const resolved = getComputedStyle(document.documentElement).getPropertyValue(match[1]).trim()
+    return resolved || value
   }
 }

--- a/lib/generators/view_primitives/add/templates/command/command_component.rb.tt
+++ b/lib/generators/view_primitives/add/templates/command/command_component.rb.tt
@@ -51,7 +51,7 @@ module UI
           class: cn(DIALOG, @extra_class),
           role: "dialog",
           "aria-modal": "true",
-          data: { action: "keydown.escape@window->command#close" }) {
+          data: { action: "keydown.esc@window->command#close" }) {
           concat content_tag(:div, class: COMMAND) {
             concat search_bar
             concat content_tag(:div, class: LIST, data: { command_target: "list" }) {

--- a/lib/generators/view_primitives/add/templates/dialog/dialog_component.rb.tt
+++ b/lib/generators/view_primitives/add/templates/dialog/dialog_component.rb.tt
@@ -40,7 +40,7 @@ module UI
           role: "dialog",
           "aria-modal": "true",
           "aria-label": @title,
-          data: { action: "keydown.escape@window->dialog#close" }) {
+          data: { action: "keydown.esc@window->dialog#close" }) {
           concat close_button
           concat header_area
           concat content_tag(:div, content) unless content.blank?

--- a/lib/generators/view_primitives/add/templates/drawer/drawer_component.rb.tt
+++ b/lib/generators/view_primitives/add/templates/drawer/drawer_component.rb.tt
@@ -36,7 +36,7 @@ module UI
           role: "dialog",
           "aria-modal": "true",
           "aria-label": @title,
-          data: { action: "keydown.escape@window->dialog#close" }) {
+          data: { action: "keydown.esc@window->dialog#close" }) {
           concat drag_handle
           concat header_area
           concat content_tag(:div, content, class: "px-4 pb-6 text-sm")

--- a/lib/generators/view_primitives/add/templates/gallery/gallery_component.rb.tt
+++ b/lib/generators/view_primitives/add/templates/gallery/gallery_component.rb.tt
@@ -40,7 +40,7 @@ module UI
       attrs = { class: grid_cls }
       if @lightbox
         attrs[:data] = { controller: "gallery",
-                         action: "click@document->gallery#closeOnClickOutside keydown.escape@document->gallery#close" }
+                         action: "click@document->gallery#closeOnClickOutside keydown.esc@document->gallery#close" }
       end
       attrs.merge!(@html_attrs)
 

--- a/lib/generators/view_primitives/add/templates/menubar/menubar_component.rb.tt
+++ b/lib/generators/view_primitives/add/templates/menubar/menubar_component.rb.tt
@@ -23,7 +23,7 @@ module UI
         class: cn(BAR, @extra_class),
         data: {
           controller: "menubar",
-          action: "click@document->menubar#closeOnClickOutside keydown.escape@document->menubar#closeAll"
+          action: "click@document->menubar#closeOnClickOutside keydown.esc@document->menubar#closeAll"
         },
         **@html_attrs) do
         menus.each { |m| concat m }

--- a/lib/generators/view_primitives/add/templates/sheet/sheet_component.rb.tt
+++ b/lib/generators/view_primitives/add/templates/sheet/sheet_component.rb.tt
@@ -48,7 +48,7 @@ module UI
           role: "dialog",
           "aria-modal": "true",
           "aria-label": @title,
-          data: { action: "keydown.escape@window->dialog#close" }) {
+          data: { action: "keydown.esc@window->dialog#close" }) {
           concat close_button
           concat header_area
           concat content_tag(:div, content, class: "flex-1") unless content.blank?


### PR DESCRIPTION
## What's broken

Found these while wiring up `chart` and `sheet` in a real app — both hit on the very first, default usage, not an edge case.

### 1. Chart renders solid black (or a single flat color) instead of the theme palette

`chart_controller.js`'s `DEFAULT_COLORS` are literal strings like `"var(--chart-1)"`, passed straight through to Chart.js's `backgroundColor`, which Chart.js hands to Canvas 2D's `fillStyle`. Canvas has no CSS cascade — `fillStyle` can't resolve CSS custom properties, so it silently falls back to black. Separately, `pie`/`doughnut`/`polarArea` charts usually have a single dataset with one color *per data point*, but coloring was assigned per *dataset* — so a single-dataset pie/doughnut got one solid color for every segment instead of a palette.

**Repro:** generate `chart`, render `ui :chart, type: :doughnut, labels: [...], datasets: [{data: [1,2,3]}]` — every segment is black.

**Fix:** resolve `var(--x)` via `getComputedStyle` before handing colors to Chart.js, and build a per-data-point color array for single-dataset pie/doughnut/polarArea instead of a per-dataset color.

### 2. Esc doesn't close Dialog / Sheet / Drawer / Command / Menubar / Gallery

All six use the Stimulus action `keydown.escape@window->...#close`. Stimulus only recognizes the `esc` alias for the Escape key — `escape` isn't in its key-filter list, so the action never binds and Stimulus throws `contains unknown key filter: escape` in the console on every keypress while the overlay is open. Esc does nothing.

**Fix:** `keydown.escape` → `keydown.esc` (matches Stimulus's actual [key filter list](https://stimulus.hotwired.dev/reference/actions#keyboardevent-filter)).

## Verification

- `bundle exec rake test` — 464 runs, 0 failures
- `bundle exec rubocop` — no offenses
- Manually verified both fixes live in a Rails 8 app: chart went from a solid black circle to correctly themed per-segment colors; Sheet went from throwing on Esc (panel stuck open) to closing normally.

## Commits

1. `fix(dialog,sheet,drawer,command,menubar,gallery): correct Esc key filter`
2. `fix(chart): resolve CSS vars and colorize pie/doughnut per segment`
3. `docs: changelog entries for chart and Esc-key fixes`